### PR TITLE
Correctly build settings from validateSettings payload

### DIFF
--- a/settings.go
+++ b/settings.go
@@ -43,8 +43,8 @@ func NewSettingsFromValidateSettingsPayload(payload []byte) (Settings, error) {
 
 	return newSettings(
 		payload,
-		"settings.allowedUnsafeSysctls",
-		"settings.forbiddenSysctls")
+		"allowedUnsafeSysctls",
+		"forbiddenSysctls")
 }
 
 func newSettings(payload []byte, paths ...string) (Settings, error) {


### PR DESCRIPTION
No changes needed to unit nor e2e tests.